### PR TITLE
Fix parameter encoding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,9 +96,6 @@ Vagrant.configure("2") do |config|
   end
 
   # Prepare the host that was provisioned
-  # Provisioning
-     config.vm.provision :shell, path: 'scripts/os.prep.sh', :args => [@pivnet_token, @segments]
-  # Developer Mode
-     config.vm.provision :shell, path: 'scripts/go.build.sh', :args => [@developer_mode]
-
+   config.vm.provision :shell, path: 'scripts/os.prep.sh', :args => ["#{@pivnet_token}", "#{@segments}"]
+   config.vm.provision :shell, path: 'scripts/go.build.sh', :args => ["#{@developer_mode}"]
 end


### PR DESCRIPTION
Bringing machine 'gpdb-m' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

shell provisioner:
* Shell provisioner `args` must be a string or array.