### PR TITLE
Option to download open source gpdb release

### DIFF
--- a/gpdb/cmd.go
+++ b/gpdb/cmd.go
@@ -25,6 +25,7 @@ type Command struct {
 	ListEnv   bool
 	Vars      bool
 	Always    bool
+	Github    bool
 }
 
 // Sub Command: Download
@@ -40,6 +41,12 @@ var downloadCmd = &cobra.Command{
 		if !Contains(AcceptedDownloadProduct, cmdOptions.Product) {
 			Fatalf("Invalid product option specified: %s, Accepted Options: %v", cmdOptions.Product, AcceptedDownloadProduct)
 		}
+		// If user want to download from github, then version of gpdb version 6 and above is only allowed
+		if cmdOptions.Version != "" && cmdOptions.Github {
+			if !isThisGPDB6xAndAbove() {
+				Fatalf("Open source download only works with GPDB 6.x and above")
+			}
+		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Run download to download the binaries
@@ -52,8 +59,9 @@ func downloadFlags() {
 	downloadCmd.Flags().StringVarP(&cmdOptions.Product, "product", "p", "gpdb", "What product do you want to download? [OPTIONS: gpdb, gpcc, gpextras]")
 	downloadCmd.Flags().StringVarP(&cmdOptions.Version, "version", "v", "", "OPTIONAL: Which GPDB version software do you want to download ?")
 	downloadCmd.Flags().BoolVar(&cmdOptions.Install, "install", false, "OPTIONAL: Install after downloaded (Only works with \"gpdb\")?")
-	downloadCmd.Flags().BoolVarP(&cmdOptions.Always, "always", "a", false, "Download the product, even if its already exists")
+	downloadCmd.Flags().BoolVarP(&cmdOptions.Always, "always", "a", false, "Download the product, even if it already exists")
 	downloadCmd.Flags().BoolVarP(&cmdOptions.ListEnv, "list", "l", false, "Show all the products that was downloaded")
+	downloadCmd.Flags().BoolVarP(&cmdOptions.Github, "github", "g", false, "Download the product from open source github release (only works with gpdb 6 & above)")
 }
 
 // Sub Command: Install

--- a/gpdb/config.go
+++ b/gpdb/config.go
@@ -63,11 +63,13 @@ func endWithSlash(path string) string {
 
 // Validate the token
 func validateToken() {
-	if IsValueEmpty(Config.DOWNLOAD.APITOKEN) || Config.DOWNLOAD.APITOKEN == "<API TOKEN>" {
+	if !cmdOptions.Github && (IsValueEmpty(Config.DOWNLOAD.APITOKEN) || Config.DOWNLOAD.APITOKEN == "<API TOKEN>") {
 		// Check if its set as environment variables
 		token := os.Getenv("UAA_API_TOKEN")
 		if token == "" { // No token set
-			Fatal("The API Token is either missing or not provided, please update the config file and try again")
+			Fatal("The API Token is either missing or not provided, please update the config file and try again" +
+				", if you don't have a pivnet account and wish to use the open source gpdb release, " +
+				"use the flag \"-g\".")
 		} else {
 			Config.DOWNLOAD.APITOKEN = token
 		}

--- a/gpdb/config.go
+++ b/gpdb/config.go
@@ -69,7 +69,7 @@ func validateToken() {
 		if token == "" { // No token set
 			Fatal("The API Token is either missing or not provided, please update the config file and try again" +
 				", if you don't have a pivnet account and wish to use the open source gpdb release, " +
-				"use the flag \"-g\".")
+				"please use the\"--github\" flag.")
 		} else {
 			Config.DOWNLOAD.APITOKEN = token
 		}

--- a/gpdb/download.go
+++ b/gpdb/download.go
@@ -381,7 +381,7 @@ func Download() {
 		token = ""
 
 		// Extract the file and download URL for the github release
-		file, downloadURL, size := openSourceReleases.extractOpenSourceReleases()
+		file, downloadURL, size := openSourceReleases.fetchOpenSourceReleases()
 
 		// Assign the open source file details to the download request
 		r.UserRequest.ProductFileName = file

--- a/gpdb/download.go
+++ b/gpdb/download.go
@@ -342,7 +342,7 @@ func (r *Responses) ExtractFileNamePlusSize(token string) {
 }
 
 // Extract the releases info from github
-func (g *GithubReleases) extractOpenSourceReleases() (string, string, int64) {
+func (g *GithubReleases) fetchOpenSourceReleases() (string, string, int64) {
 	Infof("Requesting data from open source API")
 	// Get all the open source releases
 	response := get(OpenSourceReleaseAPIEndpoint, "")

--- a/gpdb/download.go
+++ b/gpdb/download.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // All the PivNet Url's & Constants
@@ -14,6 +15,7 @@ const (
 	RefreshToken = EndPoint + "/api/v2/authentication/access_tokens"
 	Products     = EndPoint + "/api/v2/products"
 	ProductSlug  = "pivotal-gpdb" // we only care about this slug rest we ignore
+	OpenSourceReleaseAPIEndpoint = "https://api.github.com/repos/greenplum-db/gpdb/releases"
 )
 
 var (
@@ -26,6 +28,8 @@ var (
 	rx_gpdb_for_6_n_above = `(greenplum-db-(\d+\.)(\d+\.)(\d+)?(\.\d)-rhel5-x86_64.zip|Greenplum Database ` +
 		`(\d+\.)(\d+\.)(\d+)?(\-beta)?(\.\d)?( (Binary Installer|Installer))?( |  )for ` +
 		`((Red Hat Enterprise|RedHat Enterprise|RedHat Entrerprise) Linux|RHEL).*?(7))`
+	// Open Source release
+	rx_open_source_gpdb = `greenplum-(db|database)-(\d+\.)(\d+\.)(\d+)?(\-beta)?(\.\d)?-rhel7-x86_64.rpm`
 )
 
 // Struct to where all the API response will be stored
@@ -165,6 +169,79 @@ type Responses struct {
 	UserRequest  userChoice
 }
 
+type GithubReleases []struct {
+	URL             string `json:"url"`
+	AssetsURL       string `json:"assets_url"`
+	UploadURL       string `json:"upload_url"`
+	HTMLURL         string `json:"html_url"`
+	ID              int    `json:"id"`
+	NodeID          string `json:"node_id"`
+	TagName         string `json:"tag_name"`
+	TargetCommitish string `json:"target_commitish"`
+	Name            string `json:"name"`
+	Draft           bool   `json:"draft"`
+	Author          struct {
+		Login             string `json:"login"`
+		ID                int    `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"author"`
+	Prerelease  bool      `json:"prerelease"`
+	CreatedAt   time.Time `json:"created_at"`
+	PublishedAt time.Time `json:"published_at"`
+	Assets      []struct {
+		URL      string `json:"url"`
+		ID       int    `json:"id"`
+		NodeID   string `json:"node_id"`
+		Name     string `json:"name"`
+		Label    string `json:"label"`
+		Uploader struct {
+			Login             string `json:"login"`
+			ID                int    `json:"id"`
+			NodeID            string `json:"node_id"`
+			AvatarURL         string `json:"avatar_url"`
+			GravatarID        string `json:"gravatar_id"`
+			URL               string `json:"url"`
+			HTMLURL           string `json:"html_url"`
+			FollowersURL      string `json:"followers_url"`
+			FollowingURL      string `json:"following_url"`
+			GistsURL          string `json:"gists_url"`
+			StarredURL        string `json:"starred_url"`
+			SubscriptionsURL  string `json:"subscriptions_url"`
+			OrganizationsURL  string `json:"organizations_url"`
+			ReposURL          string `json:"repos_url"`
+			EventsURL         string `json:"events_url"`
+			ReceivedEventsURL string `json:"received_events_url"`
+			Type              string `json:"type"`
+			SiteAdmin         bool   `json:"site_admin"`
+		} `json:"uploader"`
+		ContentType        string    `json:"content_type"`
+		State              string    `json:"state"`
+		Size               int64       `json:"size"`
+		DownloadCount      int64       `json:"download_count"`
+		CreatedAt          time.Time `json:"created_at"`
+		UpdatedAt          time.Time `json:"updated_at"`
+		BrowserDownloadURL string    `json:"browser_download_url"`
+	} `json:"assets"`
+	TarballURL string `json:"tarball_url"`
+	ZipballURL string `json:"zipball_url"`
+	Body       string `json:"body"`
+}
+
 // Extract all the Pivotal Network Product from the Product API page.
 func (r *Responses) extractProduct(token string) {
 	Info("Obtaining the product ID")
@@ -264,6 +341,22 @@ func (r *Responses) ExtractFileNamePlusSize(token string) {
 	Debugf("Product File Size: %v", r.UserRequest.ProductFileSize)
 }
 
+// Extract the releases info from github
+func (g *GithubReleases) extractOpenSourceReleases() (string, string, int64) {
+	Infof("Requesting data from open source API")
+	// Get all the open source releases
+	response := get(OpenSourceReleaseAPIEndpoint, "")
+
+	// Store it on JSON
+	err := json.Unmarshal(response, &g)
+	if err != nil {
+		Fatalf("Unable to unmarshal the open source gpdb releases: %v", err)
+	}
+
+	// The filename and the download URL
+	return showOpenSourceVersionAvailable(*g)
+}
+
 // Download the the product from PivNet
 func Download() {
 
@@ -277,18 +370,35 @@ func Download() {
 
 	Info("Starting the program to download the product")
 
-	// Get the authentication token
-	token := getToken()
-
-	// Initialize the struct
+	// Initialize the struct & token
 	r := new(Responses)
+	var token string
 
-	// Extract all the product list / releases information
-	r.extractProduct(token)
+	// If its a open source release download
+	if cmdOptions.Github {
+		// No token for open source release
+		token = ""
 
-	// Accept the EULA
-	Infof("Accepting the EULA (End User License Agreement): %s", r.EULALink)
-	post(r.EULALink, token)
+		// Extract the file and download URL for the github release
+		openSourceReleases := new(GithubReleases)
+		file, downloadURL, size := openSourceReleases.extractOpenSourceReleases()
+
+		// Assign the open source file details to the download request
+		r.UserRequest.ProductFileName = file
+		r.UserRequest.DownloadURL = downloadURL
+		r.UserRequest.ProductFileSize = size
+
+	} else { // if its a official enterprise download
+		// Get the authentication token
+		token = getToken()
+
+		// Extract all the product list / releases information
+		r.extractProduct(token)
+
+		// Accept the EULA
+		Infof("Accepting the EULA (End User License Agreement): %s", r.EULALink)
+		post(r.EULALink, token)
+	}
 
 	// All hard work is now done, lets download the version
 	Infof("Starting downloading of file: %s", r.UserRequest.ProductFileName)

--- a/gpdb/download.go
+++ b/gpdb/download.go
@@ -354,7 +354,7 @@ func (g *GithubReleases) extractOpenSourceReleases() (string, string, int64) {
 	}
 
 	// The filename and the download URL
-	return showOpenSourceVersionAvailable(*g)
+	return ShowOpenSourceAvailableVersion(*g)
 }
 
 // Download the the product from PivNet
@@ -372,6 +372,7 @@ func Download() {
 
 	// Initialize the struct & token
 	r := new(Responses)
+	openSourceReleases := new(GithubReleases)
 	var token string
 
 	// If its a open source release download
@@ -380,7 +381,6 @@ func Download() {
 		token = ""
 
 		// Extract the file and download URL for the github release
-		openSourceReleases := new(GithubReleases)
 		file, downloadURL, size := openSourceReleases.extractOpenSourceReleases()
 
 		// Assign the open source file details to the download request

--- a/gpdb/download.go
+++ b/gpdb/download.go
@@ -11,10 +11,10 @@ import (
 
 // All the PivNet Url's & Constants
 const (
-	EndPoint     = "https://network.pivotal.io"
-	RefreshToken = EndPoint + "/api/v2/authentication/access_tokens"
-	Products     = EndPoint + "/api/v2/products"
-	ProductSlug  = "pivotal-gpdb" // we only care about this slug rest we ignore
+	EndPoint                     = "https://network.pivotal.io"
+	RefreshToken                 = EndPoint + "/api/v2/authentication/access_tokens"
+	Products                     = EndPoint + "/api/v2/products"
+	ProductSlug                  = "pivotal-gpdb" // we only care about this slug rest we ignore
 	OpenSourceReleaseAPIEndpoint = "https://api.github.com/repos/greenplum-db/gpdb/releases"
 )
 
@@ -231,8 +231,8 @@ type GithubReleases []struct {
 		} `json:"uploader"`
 		ContentType        string    `json:"content_type"`
 		State              string    `json:"state"`
-		Size               int64       `json:"size"`
-		DownloadCount      int64       `json:"download_count"`
+		Size               int64     `json:"size"`
+		DownloadCount      int64     `json:"download_count"`
 		CreatedAt          time.Time `json:"created_at"`
 		UpdatedAt          time.Time `json:"updated_at"`
 		BrowserDownloadURL string    `json:"browser_download_url"`

--- a/gpdb/helpers.go
+++ b/gpdb/helpers.go
@@ -342,3 +342,14 @@ func isCommandAvailable(name string) bool {
 	}
 	return true
 }
+
+// Check if the file exists
+func DidWeDownloadThisVersionBefore(pattern, mesg string) bool {
+	filePath, _ := FilterDirsGlob(Config.DOWNLOAD.DOWNLOADDIR, fmt.Sprintf(pattern, cmdOptions.Version))
+	if len(filePath) > 0 && !cmdOptions.Always {
+		Warnf("%s %s found, skipping download...", mesg, filePath[0])
+		Warn("To force re-download of the file, use -a flag")
+		return true
+	}
+	return false
+}

--- a/gpdb/helpers.go
+++ b/gpdb/helpers.go
@@ -310,7 +310,7 @@ func isValidVersionFormat(version string) bool {
 }
 
 // Extract the version from the name
-func extractVersionNumbeer(filename string) string {
+func extractVersionNumber(filename string) string {
 	r, _ := regexp.Compile(`(-[0-9]+.[0-9]+.[0-9]+-|-[0-9]+.[0-9]+.[0-9]+.[0-9]+-)`)
 	version := r.FindString(filename)
 	return strings.Replace(version, "-", "", -1)

--- a/gpdb/install.go
+++ b/gpdb/install.go
@@ -143,5 +143,5 @@ func chooseDownloadedProducts() string {
 	totalProducts := displayDownloadedProducts("listandChoose")
 	choice := PromptChoice(len(totalProducts))
 	choosenProduct := totalProducts[choice-1]
-	return extractVersionNumbeer(choosenProduct)
+	return extractVersionNumber(choosenProduct)
 }

--- a/gpdb/interactions.go
+++ b/gpdb/interactions.go
@@ -141,8 +141,14 @@ func pickUserChoice(ReleaseOutputMap, ReleaseFileOutPutMap map[string]string,
 		return ReleaseFileOutPutMap[v], ReleaseOutputMap[v], ReleaseSizeOutPutMap[v]
 	} else { // If its not on the list then fallback to interactive mode
 		// Print warning if the user did provide a value of the version
+		downloadFromWhere := "PivNet"
+		if cmdOptions.Github {
+			downloadFromWhere = "Github"
+		}
+		
 		if cmdOptions.Version != "" {
-			Warnf("Unable to find the GPDB version \"%s\" on PivNet, failing back to interactive mode..", cmdOptions.Version)
+			Warnf("Unable to find the GPDB version \"%s\" on %s, failing back to interactive mode..",
+				cmdOptions.Version, downloadFromWhere)
 		}
 
 		// Sort all the keys

--- a/gpdb/request.go
+++ b/gpdb/request.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -140,17 +139,8 @@ func downloadProduct(url, token string, r Responses) {
 	// Only would work with gpdb, for other flags like gpcc / gpextra this won't work
 	// since we don't store or request for any version information
 	if cmdOptions.Product == "gpdb" {
-		filePath, _ := FilterDirsGlob(Config.DOWNLOAD.DOWNLOADDIR, fmt.Sprintf("*%s*.zip", cmdOptions.Version))
-		if len(filePath) > 0 && !cmdOptions.Always {
-			Warnf("ZIP File %s found, skipping download...", filePath[0])
-			Warn("To force re-download of the file, use -a flag")
-			return
-		}
-
-		filePath, _ = FilterDirsGlob(Config.DOWNLOAD.DOWNLOADDIR, fmt.Sprintf("*%s*.rpm", cmdOptions.Version))
-		if len(filePath) > 0 && !cmdOptions.Always {
-			Warnf("RPM File %s found, skipping download...", filePath[0])
-			Warn("To force re-download of the file, use -a flag")
+		if DidWeDownloadThisVersionBefore("*%s*.zip", "ZIP File") ||
+			DidWeDownloadThisVersionBefore("*%s*.rpm", "RPM File") {
 			return
 		}
 	}

--- a/gpdb/request.go
+++ b/gpdb/request.go
@@ -72,7 +72,9 @@ func generateHandler(method, url, token string, download bool) (*http.Response) 
 	// Add Header to the Http Request
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", "Bearer "+token)
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	// Skip SSL stuffs
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
@@ -140,7 +142,14 @@ func downloadProduct(url, token string, r Responses) {
 	if cmdOptions.Product == "gpdb" {
 		filePath, _ := FilterDirsGlob(Config.DOWNLOAD.DOWNLOADDIR, fmt.Sprintf("*%s*.zip", cmdOptions.Version))
 		if len(filePath) > 0 && !cmdOptions.Always {
-			Warnf("File %s found. Skipping download", filePath[0])
+			Warnf("ZIP File %s found, skipping download...", filePath[0])
+			Warn("To force re-download of the file, use -a flag")
+			return
+		}
+
+		filePath, _ = FilterDirsGlob(Config.DOWNLOAD.DOWNLOADDIR, fmt.Sprintf("*%s*.rpm", cmdOptions.Version))
+		if len(filePath) > 0 && !cmdOptions.Always {
+			Warnf("RPM File %s found, skipping download...", filePath[0])
 			Warn("To force re-download of the file, use -a flag")
 			return
 		}


### PR DESCRIPTION
+ Github release now has the rpm version of greenplum db ( i.e from gpdb 6 onwards )
+ Added a flag that will switch the download from open source gpdb or offical gpdb
+ The installation procedure all remain the same

Co-Authored-By: Amil Khanzada <amilkh@users.noreply.github.com>